### PR TITLE
[DTPAYETWO-759] HW Parity PaypalAccount Representation changes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,11 @@
 Changelog
 =========
+1.7.1
+-------------------
+- Added field 'accountId' to PayPal.
+- PayPal account creation allowed using field 'accountId' which accepts Email, Phone Number, PayPal PayerID.
+- Venmo account creation allowed using field 'accountId' which accepts Email, Phone Number, Venmo Handle, Venmo External ID.
+
 1.7.0
 -------------------
 - Added missing webhook groups

--- a/hyperwallet/api.py
+++ b/hyperwallet/api.py
@@ -1537,7 +1537,7 @@ class Api(object):
         :param userToken:
             A token identifying the User. **REQUIRED**
         :param data:
-            A dictionary containing PayPal Account information. **REQUIRED**
+            A dictionary containing PayPal Account information. Required fields transferMethodCountry, transferMethodCurrency , email or accountId **REQUIRED**
         :returns:
             A PayPal Account.
         '''

--- a/hyperwallet/api.py
+++ b/hyperwallet/api.py
@@ -1554,8 +1554,8 @@ class Api(object):
         if not ('transferMethodCurrency' in data) or not (data['transferMethodCurrency']):
             raise HyperwalletException('transferMethodCurrency is required')
 
-        if not ('email' in data) or not (data['email']):
-            raise HyperwalletException('email is required')
+        if (not ('email' in data) or not (data['email'])) and (not ('accountId' in data) or not (data['accountId'])):
+            raise HyperwalletException('email/accountId is required')
 
         response = self.apiClient.doPost(
             self.__buildUrl('users', userToken, 'paypal-accounts'),

--- a/hyperwallet/api.py
+++ b/hyperwallet/api.py
@@ -1555,7 +1555,7 @@ class Api(object):
             raise HyperwalletException('transferMethodCurrency is required')
 
         if (not ('email' in data) or not (data['email'])) and (not ('accountId' in data) or not (data['accountId'])):
-            raise HyperwalletException('email/accountId is required')
+            raise HyperwalletException('email or accountId is required')
 
         response = self.apiClient.doPost(
             self.__buildUrl('users', userToken, 'paypal-accounts'),

--- a/hyperwallet/models.py
+++ b/hyperwallet/models.py
@@ -548,7 +548,8 @@ class PayPalAccount(TransferMethod):
         super(PayPalAccount, self).__init__(data)
 
         self.defaults = {
-            'email': None
+            'email': None,
+            'accountId': None
         }
 
         for (param, default) in self.defaults.items():

--- a/hyperwallet/tests/test_api.py
+++ b/hyperwallet/tests/test_api.py
@@ -1529,7 +1529,7 @@ class ApiTest(unittest.TestCase):
         with self.assertRaises(HyperwalletException) as exc:
             self.api.createPayPalAccount('token', paypal_account_data)
 
-        self.assertEqual(exc.exception.message, 'email is required')
+        self.assertEqual(exc.exception.message, 'email/accountId is required')
 
     @mock.patch('hyperwallet.utils.ApiClient._makeRequest')
     def test_create_paypal_account_success(self, mock_post):
@@ -1543,6 +1543,19 @@ class ApiTest(unittest.TestCase):
         response = self.api.createPayPalAccount('token', paypal_account_data)
 
         self.assertTrue(response.email, paypal_account_data.get('token'))
+
+    @mock.patch('hyperwallet.utils.ApiClient._makeRequest')
+    def test_create_paypal_account_accountId_success(self, mock_post):
+
+        paypal_account_data = {
+            'transferMethodCountry': 'test-transfer-method-country',
+            'transferMethodCurrency': 'test-transfer-method-currency',
+            'accountId': 'test-email'
+        }
+        mock_post.return_value = paypal_account_data
+        response = self.api.createPayPalAccount('token', paypal_account_data)
+
+        self.assertTrue(response.accountId, paypal_account_data.get('token'))
 
     def test_update_paypal_account_fail_need_user_token(self):
 

--- a/hyperwallet/tests/test_api.py
+++ b/hyperwallet/tests/test_api.py
@@ -1529,7 +1529,7 @@ class ApiTest(unittest.TestCase):
         with self.assertRaises(HyperwalletException) as exc:
             self.api.createPayPalAccount('token', paypal_account_data)
 
-        self.assertEqual(exc.exception.message, 'email/accountId is required')
+        self.assertEqual(exc.exception.message, 'email or accountId is required')
 
     @mock.patch('hyperwallet.utils.ApiClient._makeRequest')
     def test_create_paypal_account_success(self, mock_post):


### PR DESCRIPTION
JIRA Ticket: [DTPAYETWO-759](https://engineering.paypalcorp.com/jira/browse/DTPAYETWO-759)


## JIRA Tickets: 
- [Dev: DTPAYETWO-592](https://engineering.paypalcorp.com/jira/browse/DTPAYETWO-592)
- [UT/IT: DTPAYETWO-593](https://engineering.paypalcorp.com/jira/browse/DTPAYETWO-593)
-----
# Overview
**The Design Documentation can be found here: [HW Parity with Masspay (REST API)](https://engineering.paypalcorp.com/confluence/pages/viewpage.action?spaceKey=Payouts&title=HW+Parity+with+Masspay#HWParitywithMasspay-RESTAPI(JIRA:DTPAYETWO-592))**

Currently when creating External Accounts (EA) such as PayPal & Venmo through the REST API method, account numbers were specified to be the following:
 EA Type        | Account Number Type          |
| ------------ |:-----------------------:|
| PayPal       | Email                      |
| Venmo      | Phone Number      |

This has now been changed to support the following:
 EA Type        | Account Number Type          |
| ------------ |:-----------------------:|
| PayPal       | Email, Phone Number, PayPal PayerID                                      |
| Venmo      | Email, Phone Number, Venmo Handle, Venmo External ID      |

With this change, there is a new option to use the "accountId" key-value pair in the HTTP POST Request Body. When GETting an EA, the response body will show this "accountId" value as well. Users are still able to use the "email" key-value if they wish to as well. 
```
OLD:
{
    "type": "PAYPAL_ACCOUNT",
    "transferMethodCountry": "US",
    "transferMethodCurrency": "USD",
    "email": "camlau@paypal.com"
}

------------------------------------------------

NEW:
{
    "type": "PAYPAL_ACCOUNT",
    "transferMethodCountry": "US",
    "transferMethodCurrency": "USD",
    "accountId": "camlau@paypal.com"
}
```

Added new wallet attribute USE_EMAIL_TAG_FOR_PAYPAL_EA_REST_API. 

- If this is enabled for a merchant then they will continue using 'email' in API request & response representation will also have 'email'.
- If this is disabled for a merchant then they will be using 'accountId' in API request & response representation will also have 'accountId'.

Hence we have added a generic error 'email/accountId is required' to accomodate both based on wallet attribute USE_EMAIL_TAG_FOR_PAYPAL_EA_REST_API. Moving forward all merchants will start using accountId. 
