### PR TITLE
DTPAYETWO-761- Added testcases to verify "isDefaultTransferMethod" attr for get and Get List EA apis

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,9 @@
 Changelog
 =========
+1.7.1
+-------------------
+- Added attribute 'isDefaultTransferMethod' to identify default accounts.
+
 1.7.0
 -------------------
 - Added missing webhook groups

--- a/hyperwallet/tests/test_api.py
+++ b/hyperwallet/tests/test_api.py
@@ -55,6 +55,11 @@ class ApiTest(unittest.TestCase):
             'type': 'BANK_ACCOUNT'
         }
 
+        self.dataWithIsDefaultTransferAttr = {
+            'token': 'tkn-12345',
+            'isDefaultTransferMethod': True
+        }
+
         self.balance = {
             'currency': 'USD'
         }
@@ -2975,6 +2980,26 @@ class ApiTest(unittest.TestCase):
         response = self.api.listTransferMethods('token')
 
         self.assertTrue(response.token, self.data.get('token'))
+
+    @mock.patch('hyperwallet.utils.ApiClient._makeRequest')
+    def test_getBankAccount_withDefaultTransfer_success(self, mock_get):
+
+        bank_account_data = {
+            'isDefaultTransferMethod': True
+        }
+        mock_get.return_value = bank_account_data
+        response = self.api.getBankAccount('token', 'token')
+
+        self.assertTrue(response.isDefaultTransferMethod, bank_account_data.get('isDefaultTransferMethod'))
+
+    @mock.patch('hyperwallet.utils.ApiClient._makeRequest')
+    def test_list_bank_cards_withDefaultTransfer_success(self, mock_get):
+
+        mock_get.return_value = {'data': [self.dataWithIsDefaultTransferAttr]}
+        response = self.api.listBankCards('token')
+
+        self.assertTrue(response[0].token, self.data.get('token'))
+        self.assertTrue(response[0].isDefaultTransferMethod, self.data.get('isDefaultTransferMethod'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Design: https://engineering.paypalcorp.com/confluence/display/Payouts/Default+Transfer+Method+in+EA+responses

The change is to refine all of the external accounts API responses (GET, GET ALL) to include a "isDefaultTransferMethod" attribute holding a boolean value and is displayed only when the attribute is true which helps in determining the default account to which payment is made.